### PR TITLE
Use treesitter query to get timestamps and headline.

### DIFF
--- a/lua/khalorg.lua
+++ b/lua/khalorg.lua
@@ -105,10 +105,10 @@ M.get_headline_and_timestamps_in_fold_under_cursor = function()
       timestamps = vim.treesitter.get_node_text(captures[5], bufnr)
     end
 
-    if properties == nil then
+    -- The @properties capture is optional
+    if properties == nil and captures[6] then
       properties = vim.treesitter.get_node_text(captures[6], bufnr)
     end
-
   end
 
   if timestamps and headline then


### PR DESCRIPTION
Hi,

I made this pull request so that `khal add` also supports timestamps using the SCHEDULE: <2000-00-00>  format.

https://github.com/user-attachments/assets/97a66efb-5a30-4618-9b07-536e20af3eeb

